### PR TITLE
Comments And Controls

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -147,8 +147,8 @@ public class Robot extends TimedRobot
       /* 
        * Here we are using the fact that objects farther away appear higher in any FOV.
        * We can use this by finding the yOffset, doing some copy and paste math, and then comparing our shooter position to the angle returned.
-       * The only current issue is that there is no limit on this system. It can rotate as far as it wants. 
-       * This shouldn't be an issue, but it's better to be safe.
+       * There is a limit, and the shooter will stop once it reaches that limit.(Though it shouldn't ever reach that point.)
+       * After this point, the operator should manually move the shooter, because the vision is messed up in some way.
        */
       if(limelight.enabled){ // Checks That The Limelight Actually Exists At This Point
         if(limelight.getTargetVisible()){ // Checks That The Limelight Is Tracking

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -84,6 +84,10 @@ public class RobotContainer {
     Constants.DriverController.rightBumper().whileTrue(m_climber.runRight(-0.6)); // Lower Right Climber Side
     Constants.DriverController.povUp().whileTrue(new BothClimbers(m_climber)); // Raise Both Climbers
     Constants.DriverController.povDown().whileTrue(new BothClimbersDown(m_climber)); // Lower Both Climbers
+    Constants.DriverController.povLeft().onTrue(Commands.run(() -> {
+      usingVision = !usingVision;
+      m_shooter.stopPivot();
+    }));
 
     // Secondary Operator Controller
     Constants.OperatorController.y().whileTrue(new PSIntake(m_shooter, m_superstructure)); // Hold To Intake Through Shooter
@@ -103,14 +107,16 @@ public class RobotContainer {
                                      stopAmpShoot())));
     Constants.OperatorController.leftBumper().onTrue(m_intake.rotateIntake(-0.2)).onFalse(m_intake.stopRotate()); // Lower Intake
     Constants.OperatorController.rightBumper().onTrue(m_intake.rotateIntake(0.2)).onFalse(m_intake.stopRotate()); // Raise Intake
-    Constants.OperatorController.leftTrigger().whileTrue(m_shooter.rotateShooter(-0.15).alongWith(Commands.run(() -> usingVision = false))); // Lower Shooter
-    Constants.OperatorController.rightTrigger().whileTrue(m_shooter.rotateShooter(0.15).alongWith(Commands.run(() -> usingVision = false))); // Raise Shooter
+    Constants.OperatorController.leftTrigger().whileTrue(m_shooter.rotateShooter(-0.15).alongWith(Commands.run(() -> usingVision = false))); // Lower Shooter, Disables Vision
+    Constants.OperatorController.rightTrigger().whileTrue(m_shooter.rotateShooter(0.15).alongWith(Commands.run(() -> usingVision = false))); // Raise Shooter, Disables Vision
     Constants.OperatorController.povUp().whileTrue(new BothClimbers(m_climber)); // Raise Both Climbers
     Constants.OperatorController.povDown().whileTrue(new BothClimbersDown(m_climber)); // Lower Both Climbers
-    Constants.OperatorController.povLeft().onTrue(Commands.run(() -> {
+    Constants.OperatorController.povLeft().onTrue(Commands.run(() -> { // Toggle Limelight Vision
       usingVision = !usingVision;
       m_shooter.stopPivot();
     }));
+    Constants.OperatorController.povRight().onTrue(Commands.run(() -> 
+    System.out.println(m_Limelight.angleToGoalDegrees)));
   }
   // Methods used during auto to use intake. Integer values have placeholder values, and will be set later.
 

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -2,7 +2,6 @@ package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;


### PR DESCRIPTION
- Changed comments to better represent what the controls do.
- Changed a comment to do with vision processing. What it said before doesn't mean much now.
- Added bindings on both controllers. • The driver controller gains the ability to toggle vision by pressing left on the D-PAD. (povLeft) The operator controller had this ability previously. • The driver and operator controller can now display the limelight's desired angle by pressing right on the D-PAD.(povRight)
- Removed an unused import.