### PR TITLE
Vision Documentation and Shooter Rotation Disable Fix

### DIFF
--- a/src/main/deploy/example.txt
+++ b/src/main/deploy/example.txt
@@ -1,3 +1,0 @@
-Files placed in this directory will be deployed to the RoboRIO into the
-'deploy' directory in the home folder. Use the 'Filesystem.getDeployDirectory' wpilib function
-to get a proper path relative to the deploy directory.

--- a/src/main/docs/vision_documentation.txt
+++ b/src/main/docs/vision_documentation.txt
@@ -1,0 +1,129 @@
+I wanted to find a way to document how I'm making the vision(using a limelight) work.
+I'm going to use this text file, and document any changes here.
+I recommend opening each class mentioned, and reading along while observing the code yourself.
+If you find anything that might not match up with what is said, or is logically wrong, let Aidan know.
+
+Inside the subsystems folder, within the robot directory(src/main/java/frc/robot/subsystems),
+you will find a file named Limelight.java. This is where we want to start.
+
+Here, you'll find a few useful methods, along with the initialization method for the Limelight.
+This method allows us to access the limelight and whatever it sees in the code.
+
+We take a couple of things from this:
+1. Tracking ID (or tid)
+You will find this at the top of the class, and it is an integer.
+When the Limelight sees an AprilTag(QR-Code Like Symbol), it will record the data from it, which will be the tracking id.
+Each AprilTag has an ID specific to where it is on the field. This is important because we can trigger certain functions
+depending on what integer is returned. When the limelight doesn't see an AprilTag, it will return 0, in which case it will do nothing.
+We will come back to this later.
+
+2. TargetY (also known as yOffset or ty)
+When a target is present, this will tell us how high up the target is on camera.
+This is extremely useful, because we can use it to angle our shooter.
+If we're shooting into, for example, the speaker, 
+we want to make the shooter go higher the closer we are to the speaker, or we will hit the wall instead.
+Further away, we want to lower the shooter.
+We can figure out distance based on the TargetY.
+
+There is one other method to pay attention to.
+It's located near the bottom of the file, and is called periodic.
+WPILib makes any periodic method repeat constantly.
+We use this to constantly store the information named above(Tracking ID and TargetY, or tid and ty)
+
+We also use this to act on said information, and then pass off our actions to another class.
+The important thing to notice here is a variable double named angleChosen.
+This is the angle that the shooter will rotate to in certain situations.
+To get this angle, we use something called an InterpolatingDoubleTreeMap.(This, I've put at the top of the class.)
+I've named it angleChooser.
+
+When certain conditions are met(in this case, speaker AprilTags being detected), the code will run this InterpolatingDoubleTreeMap.
+It runs our TargetY through, and will return the angle for the shooter to go to, which we store in angleChosen.
+Each angle needs to be stored inside this InterpolatingDoubleTreeMap for it to know what to return.
+
+Example:
+
+If the TargetY were 0.0, and we wanted to have the shooter angle set to 30, we would input this
+inside the angleChooser:
+
+angleChooser.put(0.0, 30.0);
+
+When the TargetY is 0, it will return 30, because we have told it to. The first number is TargetY, the second is angleChosen.
+
+The programmer will go and find what angles need to be returned for different TargetY values, and put them in a list.
+If TargetY ends up being in-between these values, it will find a point in-between the two closest values.
+
+angleChooser.put(0.0, 30.0);
+angleChooser.put(1.0, 32.0);
+
+Here, TargetY being 0.5 would return 31.0
+
+In cases where the Target ID is something like the Source, there has to be a set angle, because the angle should be the same no matter what.
+At the moment, this hasn't been fully implemented, but the code will ignore the angleChooser, and instead set angleChosen by itself.
+Some commented out code in the periodic method is where this functionality is located.(This also sorts between teams, so ID's that need to be ignored are ignored.)
+
+Now that we've gone through this, we can finally go to other classes. All this for vision!
+
+We need to quickly go to the ShooterSubsystem.java class. The two important methods here at the moment are
+periodic(it's used everywhere), and getShooterPosition.
+
+We'll start with getShooterPosition(). This method does exactly what it says. We have an encoder on the shooter motor,
+and this encoder will return what we call AbsolutePosition. Here, it returns as a 360 degree angle.
+We convert this to a double. Any area that this method is used will return it.
+
+The periodic method here(remember that it loops constantly), is only used to run getShooterPosition().
+It stores this value inside of SmartDashboard, which is used often to return important values.
+We initially use this so that the drivers can see the angle live while driving, but this plays into vision as well.
+
+Finally, we make it into the final processing center for vision, Robot.java. After writing much of this, I was told
+this is a class to avoid using for stuff like this, but oh well. ¯\_(ツ)_/¯
+
+Anyways, here we use, believe it or not, another periodic! This is a special periodic, however, and is the reason
+that I decided to use Robot.java. This periodic is named TeleopPeriodic, and only acts when Teleop is enabled.
+This is important, so that the shooter isn't moving when auto is running, for example.
+
+I access both the ShooterSubsystem and Limelight class, so that I can pull information and methods from them.
+(This is the second reason I use Robot.java, it can access nearly any other class in some way.)
+I pull angleChosen from Limelight.java, and this will control everything from this point.
+The system starts by checking if vision is enabled using a boolean, and this can be changed by either
+attempting to control the shooter manually (which will forcefully stop vision entirely),
+or either driver pressing left on the D-Pad. (Which acts as a toggle. If on, turn off. If off, turn on.)
+
+Side note for testing: Pressing right will return TargetY, though this is visible inside of Shuffleboard,
+so this may not be very useful.
+
+We make sure the Limelight exists, and is enabled. During testing previously, I did experience issues with this,
+where it would return false, and nothing would happen. Be sure to test and be sure about this.
+
+Finally, we check if the target is visible, or if tid is set to 0. Nothing should ever happen if this is the case.
+
+After these checks, we get to the fun stuff, getting the shooter to react to vision tracking.
+
+We start by getting the ShooterPosition from SmartDashboard.
+We use multiple if-else statements here.
+Unfortunately, we can't say ShooterSubsystem.rotateAngle(angleChosen), and have the motor find that angle.
+We have to manually figure out which direction the motor needs to go to reach it's destination. (Sounds like driving school or something)
+
+I'll sort of read the code in more readable English.
+
+If the shooter's current position is lower than angleChosen, then we need to raise the shooter.
+
+The method rotatePivot is used to move the shooter. You can see that a negative number will raise the shooter.
+A positive number will lower the shooter.
+
+ if(SmartDashboard.getNumber("Shooter Position", 0) < limelight.angleChosen){
+              shooterSubsystem.rotatePivot(-0.1);
+            }
+
+If that isn't true, then we need to check if the shooter's current position is higher than angleChosen. In that case, we lower
+the shooter to reach angleChosen.
+
+Finally, if neither of the other two are the case, then we check if the shooter position is right on angleChosen.
+In that case, we stop the shooter using the method stopPivot.
+ShooterPosition isn't extremely precise(it usually is a very long decimal that changes rapidly),
+so the chance of this ever stopping the shooter moving is unlikely. This is probably the biggest downside of this code.
+The shooter will simply go back and forth, hovering around the point it needs to reach.
+
+This is most everything that the vision is done, though somewhat simplified. I hope to make the code more readable,
+but this works for now.
+
+

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@ package frc.robot;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.subsystems.Limelight;
@@ -149,21 +150,19 @@ public class Robot extends TimedRobot
     if(m_robotContainer.usingVision){ // Makes sure the Limelight Never Rotates The Shooter Unless It Is Supposed To.
       if(limelight.enabled){ // Checks That The Limelight Actually Exists At This Point
         if(limelight.getTargetVisible()){ // Checks That The Limelight Is Tracking
-            if(shooterSubsystem.getShooterPosition() < limelight.angleChosen){ // Lower Than Wanted Angle
+            if(SmartDashboard.getNumber("Shooter Position", 0) < limelight.angleChosen){ // Lower Than Wanted Angle
               shooterSubsystem.rotatePivot(-0.1); // Negative For Raising Shooter, Speed Is Decreased From 0.15 to 0.10
-            } else if(shooterSubsystem.getShooterPosition() > limelight.angleChosen){
+            } else if(SmartDashboard.getNumber("Shooter Position", 0) > limelight.angleChosen){
               shooterSubsystem.rotatePivot(0.1); // Positive For Lowering Shooter
-            } else if(shooterSubsystem.getShooterPosition() == limelight.angleChosen){
+            } else if(SmartDashboard.getNumber("Shooter Position", 0) == limelight.angleChosen){
               shooterSubsystem.stopPivot(); // Angle Is Correct, So There Is No Need To Change It
             }
           } else {
-            shooterSubsystem.stopPivot(); // Beyond Limit, So We Need To Switch To Manual
+            shooterSubsystem.stopPivot(); // No Target, So No Point
           }
         } else {
-          shooterSubsystem.stopPivot(); // No Target, So No Point
+          shooterSubsystem.stopPivot(); // Limelight Is Not On, Or Isn't Stored Inside Code. Something is wrong if this is an issue.
       }
-    } else {
-      shooterSubsystem.stopPivot();
     }
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -77,7 +77,7 @@ public class RobotContainer {
     Constants.DriverController.y().whileTrue(
         Commands.deferredProxy(() -> drivebase.driveToPose(
                                    new Pose2d(new Translation2d(4, 4), Rotation2d.fromDegrees(0)))
-                              )); // ? We may never know..
+                              )); // ? We may never know.. Something with swerve, I believe
     Constants.DriverController.leftTrigger().whileTrue(m_climber.runLeft(0.6)); // Raise Left Climber Side
     Constants.DriverController.rightTrigger().whileTrue(m_climber.runRight(0.6)); // Raise Right Climber Side
     Constants.DriverController.leftBumper().whileTrue(m_climber.runLeft(-0.6)); // Lower Left Climber Side
@@ -113,12 +113,14 @@ public class RobotContainer {
     Constants.OperatorController.leftTrigger().whileTrue(m_shooter.rotateShooter(-0.15).alongWith(Commands.runOnce(() -> { 
       if(usingVision){
         usingVision = false;
+        m_shooter.stopPivot(); // Stops shooter momentarily, but will start again almost immediately
         printUsingVision();
       }
     }))); // Lower Shooter, Disables Vision
     Constants.OperatorController.rightTrigger().whileTrue(m_shooter.rotateShooter(0.15).alongWith(Commands.runOnce(() -> {
       if(usingVision){
         usingVision = false;
+        m_shooter.stopPivot(); // Stops shooter momentarily, but will start again almost immediately
         printUsingVision();
       }
     }))); // Raise Shooter, Disables Vision

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -67,7 +67,7 @@ public class Limelight extends SubsystemBase {
     /*
      * Methods Like This Will Be Used When A Certain AprilTag Always Has The Same Angle When Using It's Function.
      * The Source Only Has One Angle, So It Fits Within This Description.
-     * More Methods Like This May Be Added Later
+     * More Methods Like This May Be Added Later, Depending On Our Needs
      */
     public void sourceAprilTag() {
       angleChosen = 30.0;
@@ -89,7 +89,7 @@ public class Limelight extends SubsystemBase {
         tid = table.getEntry("tid");
         trackingID = (int) tid.getDouble(0.0);
 
-        // Possible Pipeline Stuff. Switch Statement will be modified if this works.
+        // Possible Pipeline Stuff. Switch Statement will be modified if this works. If it does I'll be very happy.
         /*if(DriverStation.getAlliance().equals(Optional.of(DriverStation.Alliance.Blue))){
           table.getEntry("pipeline").setNumber(0); // Blue pipeline
         } else if(DriverStation.getAlliance().equals(Optional.of(DriverStation.Alliance.Red))){
@@ -115,7 +115,7 @@ public class Limelight extends SubsystemBase {
               speakerAprilTag();
               break;
             default:
-              // Do nothing, the AprilTag is red.
+              // Do nothing, the AprilTag is red, or it is not present on the camera.
               break;
           }
         } else if(DriverStation.getAlliance().equals(Optional.of(DriverStation.Alliance.Red))){
@@ -136,7 +136,7 @@ public class Limelight extends SubsystemBase {
               speakerAprilTag();
               break;
             default:
-              // Do nothing, the AprilTag is blue.
+              // Do nothing, the AprilTag is blue, or it is not present on camera.
               break;
           }
         } */


### PR DESCRIPTION
Added text file explaining all of my vision work, and also fixed an issue that came after removing the limit, that the shooter would constantly stop moving. I also added some stop moving methods when toggling vision by pressing a trigger as the operator(co-driver), which should add extra protection to the shooter. A person can stop everything the shooter is doing by pressing a trigger.